### PR TITLE
リモートユーザーとのコミュニケーションを制限できるように

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
 	"host": "http://localhost:3000",
 	"i": "xxxxxxxx",
 	"master": "admin",
+	"restrictCommunication": false,
 	"notingEnabled": true,
 	"keywordEnabled": true,
 	"chartEnabled": true,

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -168,6 +168,14 @@ export default class 藍 {
 			if (data.userId == this.account.id) return; // 自分は弾く
 			if (data.text == null && (data.files || []).length == 0) return;
 
+			if (data.user.isBot) {
+				return;
+			}
+
+			if (config.restrictCommunication && data.user.host != null) {
+				return;
+			}
+
 			// リアクションする
 			this.api('notes/reactions/create', {
 				noteId: data.id,
@@ -220,6 +228,14 @@ export default class 藍 {
 		// To avoid infinity reply loop.
 		if (msg.user.isBot) {
 			return;
+		}
+
+		// コミュニケーション対象の制限が有効
+		if (config.restrictCommunication) {
+			// フォロワー0のリモートユーザー
+			if (msg.user.host != null && msg.friend.doc.user.followersCount === 0) {
+				return;
+			}
 		}
 
 		const isNoContext = msg.replyId == null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ type Config = {
 	master?: string;
 	wsUrl: string;
 	apiUrl: string;
+	restrictCommunication: boolean;
 	keywordEnabled: boolean;
 	reversiEnabled: boolean;
 	notingEnabled: boolean;

--- a/src/friend.ts
+++ b/src/friend.ts
@@ -18,6 +18,18 @@ export type FriendDoc = {
 	reversiStrength?: number | null;
 };
 
+function formatUser(value: User): User {
+	return {
+		id: value.id,
+		name: value.name,
+		username: value.username,
+		host: value.host,
+		isFollowing: value.isFollowing,
+		isBot: value.isBot,
+		followersCount: value.followersCount,
+	};
+}
+
 export default class Friend {
 	private ai: 藍;
 
@@ -50,7 +62,7 @@ export default class Friend {
 			if (exist == null) {
 				const inserted = this.ai.friends.insertOne({
 					userId: opts.user.id,
-					user: opts.user
+					user: formatUser(opts.user)
 				});
 
 				if (inserted == null) {
@@ -60,7 +72,7 @@ export default class Friend {
 				this.doc = inserted;
 			} else {
 				this.doc = exist;
-				this.doc.user = { ...this.doc.user, ...opts.user };
+				this.doc.user = formatUser({ ...this.doc.user, ...opts.user });
 				this.save();
 			}
 		} else if (opts.doc) {
@@ -72,10 +84,10 @@ export default class Friend {
 
 	@bindThis
 	public updateUser(user: Partial<User>) {
-		this.doc.user = {
+		this.doc.user = formatUser({
 			...this.doc.user,
 			...user,
-		};
+		});
 		this.save();
 	}
 

--- a/src/misskey/user.ts
+++ b/src/misskey/user.ts
@@ -5,4 +5,5 @@ export type User = {
 	host?: string | null;
 	isFollowing?: boolean;
 	isBot: boolean;
+	followersCount?: number;
 };


### PR DESCRIPTION
- リモートユーザーとのコミュニケーションを制限できるように
  - config.jsonで`restrictCommunication`に`true`を設定する
  - メンション・リプライでフォロワー0のリモートユーザーに反応しない
  - 引用リノートされたときにリモートユーザーにリアクションしない
- DBのfriendsコレクションにドキュメントを挿入・更新するときに、ドキュメントのuserから余計なプロパティを除くように
  - pinnedNotesなどがかなり容量を食う